### PR TITLE
#32 Work on changing object ownership

### DIFF
--- a/src/Axis.cpp
+++ b/src/Axis.cpp
@@ -47,7 +47,7 @@ Axis::Axis(Figure &figure, const bfloat2_t &area)
 
 std::shared_ptr<Plot1D> Axis::plot_impl(std::vector<vfloat2_t> &&values,
                                         const std::string &label) {
-  m_plot1d.emplace_back(new Plot1D(*this));
+  m_plot1d.emplace_back(std::make_shared<Plot1D>(*this));
   m_children.push_back(&*m_plot1d.back());
   m_plot1d.back()->add_values(std::move(values), 0);
   m_plot1d.back()->set_color(default_colors[m_plot1d.size() - 1]);

--- a/src/Figure.cpp
+++ b/src/Figure.cpp
@@ -44,11 +44,12 @@ int Figure::m_num_windows = 0;
 Figure::Figure(const std::array<float, 2> &pixels)
     : Drawable(nullptr,
                bfloat2_t(vfloat2_t(0, 0), vfloat2_t(pixels[0], pixels[1]))),
-      m_id(++m_num_windows),
-      m_axis(new Axis(*this, bfloat2_t({0.1f, 0.1f}, {0.9f, 0.9f}))) {
-  m_children.push_back(&*m_axis);
+      m_id(++m_num_windows), m_axes{std::make_shared<Axis>(
+                                 *this,
+                                 bfloat2_t({0.1f, 0.1f}, {0.9f, 0.9f}))} {
+  m_children.push_back(m_axes.back().get());
   m_pixels = m_area;
-  m_axis->resize(m_pixels);
+  m_axes.back()->resize(m_pixels);
 }
 
 } // namespace trase

--- a/src/Figure.cpp
+++ b/src/Figure.cpp
@@ -44,12 +44,18 @@ int Figure::m_num_windows = 0;
 Figure::Figure(const std::array<float, 2> &pixels)
     : Drawable(nullptr,
                bfloat2_t(vfloat2_t(0, 0), vfloat2_t(pixels[0], pixels[1]))),
-      m_id(++m_num_windows), m_axes{std::make_shared<Axis>(
-                                 *this,
-                                 bfloat2_t({0.1f, 0.1f}, {0.9f, 0.9f}))} {
-  m_children.push_back(m_axes.back().get());
+      m_id(++m_num_windows) {
   m_pixels = m_area;
-  m_axes.back()->resize(m_pixels);
 }
+
+std::shared_ptr<Axis> Figure::axis() noexcept {
+  m_axes.emplace_back(
+      std::make_shared<Axis>(*this, bfloat2_t({0.1f, 0.1f}, {0.9f, 0.9f})));
+  m_axes.back()->resize(m_pixels);
+  m_children.push_back(m_axes.back().get());
+  return m_axes.back();
+}
+
+std::shared_ptr<Axis> Figure::axis(int n) { return m_axes.at(n); }
 
 } // namespace trase

--- a/src/Figure.hpp
+++ b/src/Figure.hpp
@@ -59,7 +59,13 @@ class Figure : public Drawable {
 public:
   explicit Figure(const std::array<float, 2> &pixels);
 
-  std::shared_ptr<Axis> axis() { return m_axes.back(); }
+  /// Create a new axis and return a shared pointer to it
+  std::shared_ptr<Axis> axis() noexcept;
+
+  /// Return a shared pointer to an existing axis.
+  /// Throws std::out_of_range exception if out of range.
+  /// \param n the axis to return
+  std::shared_ptr<Axis> axis(int n);
 
   template <typename Backend> void serialise(Backend &backend);
   template <typename Backend> void show(Backend &backend);

--- a/src/Figure.hpp
+++ b/src/Figure.hpp
@@ -51,7 +51,7 @@ class Figure : public Drawable {
   int m_id;
 
   /// the axis object for this figure
-  std::shared_ptr<Axis> m_axis;
+  std::vector<std::shared_ptr<Axis>> m_axes;
 
   /// total number of figures currentl created
   static int m_num_windows;
@@ -59,7 +59,7 @@ class Figure : public Drawable {
 public:
   explicit Figure(const std::array<float, 2> &pixels);
 
-  std::shared_ptr<Axis> axis() { return m_axis; }
+  std::shared_ptr<Axis> axis() { return m_axes.back(); }
 
   template <typename Backend> void serialise(Backend &backend);
   template <typename Backend> void show(Backend &backend);

--- a/src/FigureDraw.hpp
+++ b/src/FigureDraw.hpp
@@ -40,7 +40,7 @@ namespace trase {
 template <typename Backend> void Figure::serialise(Backend &backend) {
   auto name = "Figure " + std::to_string(m_id);
   backend.init(m_pixels.bmax[0], m_pixels.bmax[1], m_time_span, name.c_str());
-  m_axis->serialise(backend);
+  m_axes.back()->serialise(backend);
   backend.finalise();
 }
 
@@ -53,19 +53,19 @@ template <typename Backend> void Figure::show(Backend &backend) {
     const vfloat2_t win_limits = backend.begin_frame();
     if ((win_limits != m_pixels.bmax).any()) {
       m_pixels.bmax = win_limits;
-      m_axis->resize(m_pixels);
+      m_axes.back()->resize(m_pixels);
     }
 
     if (backend.mouse_dragging()) {
       vfloat2_t delta = backend.mouse_drag_delta();
 
       // scale by axis pixel area
-      delta /= m_axis->pixels().bmax * vfloat2_t(-1, 1);
+      delta /= m_axes.back()->pixels().bmax * vfloat2_t(-1, 1);
 
       // scale by axis limits
-      delta *= m_axis->limits().delta();
+      delta *= m_axes.back()->limits().delta();
 
-      m_axis->limits() += delta;
+      m_axes.back()->limits() += delta;
       backend.mouse_drag_reset_delta();
     }
 
@@ -80,7 +80,7 @@ template <typename Backend> void Figure::show(Backend &backend) {
 
 template <typename Backend>
 void Figure::draw(Backend &backend, const float time) {
-  m_axis->draw(backend, time);
+  m_axes.back()->draw(backend, time);
 }
 
 } // namespace trase

--- a/tests/TestFigure.cpp
+++ b/tests/TestFigure.cpp
@@ -47,3 +47,16 @@ TEST_CASE("figure can be created", "[figure]") {
   auto fig1 = figure();
   auto fig2 = figure({800, 600});
 }
+
+
+TEST_CASE("axis methods can be invoked", "[figure]") {
+  auto fig = figure();
+
+  CHECK_NOTHROW(fig->axis());
+  CHECK_NOTHROW(fig->axis());
+  CHECK_NOTHROW(fig->axis(0));
+  CHECK_NOTHROW(fig->axis(1));
+
+  CHECK_THROWS_AS(fig->axis(2), std::out_of_range);
+  CHECK_THROWS_AS(fig->axis(-1), std::out_of_range);
+}


### PR DESCRIPTION
Currently doesn't allow more than one item in each vector, and every method works on the `back()` of the vector.