### PR TITLE
Issue 74 histogram

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ set (trase_headers
     src/frontend/Geometry.hpp
     src/frontend/Line.hpp
     src/frontend/Points.hpp
+    src/frontend/Histogram.hpp
     src/util/ColumnIterator.hpp
     src/util/BBox.hpp
     src/util/Colors.hpp
@@ -159,6 +160,8 @@ set (trase_source
     src/frontend/Drawable.cpp
     src/frontend/Figure.cpp
     src/frontend/Plot1D.cpp
+    src/frontend/Transform.cpp
+    src/frontend/Histogram.cpp
     src/util/Colors.cpp
     src/util/Style.cpp
     )

--- a/src/backend/BackendSVG.cpp
+++ b/src/backend/BackendSVG.cpp
@@ -151,20 +151,20 @@ void BackendSVG::add_animated_rect(const bfloat2_t &x, float time) {
 void BackendSVG::end_animated_rect() {
 
   m_animate_times.back() = '\"';
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 4; ++i) {
     m_animate_values[i].back() = '\"';
   }
-  const std::string names[3] = {"cx", "cy", "r"};
-  for (int i = 0; i < 3; ++i) {
+  const std::string names[4] = {"x", "y", "width", "height"};
+  for (int i = 0; i < 4; ++i) {
     m_out << "<animate attributeName=\"" + names[i] +
                  "\" repeatCount=\"indefinite\" begin =\"0s\" dur=\""
           << m_time_span << "s\" " << m_animate_values[i] << ' '
           << m_animate_times << "/>\n";
   }
-  circle_end();
+  rect_end();
   m_animate_times.clear();
 
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 4; ++i) {
     m_animate_values[i].clear();
   }
 }

--- a/src/backend/BackendSVG.cpp
+++ b/src/backend/BackendSVG.cpp
@@ -86,7 +86,7 @@ void BackendSVG::rounded_rect(const bfloat2_t &x, const float r) noexcept {
   rect(x, r);
 }
 
-void BackendSVG::rect(const bfloat2_t &x, const float r) noexcept {
+void BackendSVG::rect_begin(const bfloat2_t &x, float r) noexcept {
 
   const auto &delta = x.delta();
   vfloat2_t min = x.min();
@@ -112,7 +112,62 @@ void BackendSVG::rect(const bfloat2_t &x, const float r) noexcept {
           << m_onmouseout_tooltip << '\"';
   }
 
-  m_out << "/>\n";
+  m_out << ">\n";
+}
+
+void BackendSVG::rect_end() noexcept { m_out << "</rect>\n"; }
+
+void BackendSVG::rect(const bfloat2_t &x, const float r) noexcept {
+  rect_begin(x, r);
+  rect_end();
+}
+
+void BackendSVG::add_animated_rect(const bfloat2_t &x, const float r,
+                                   float time) {
+
+  const auto &delta = x.delta();
+  vfloat2_t min = x.min();
+
+  // check if first rect
+  if (m_animate_times.empty()) {
+    rect_begin(x, r);
+
+    if (m_animate_values.size() < 4) {
+      m_animate_values.resize(4);
+    }
+    m_animate_times = "keyTimes=\"" + std::to_string(time / m_time_span) + ';';
+    m_animate_values[0] = "values=\"" + std::to_string(min[0]) + ';';
+    m_animate_values[1] = "values=\"" + std::to_string(min[1]) + ';';
+    m_animate_values[2] = "values=\"" + std::to_string(delta[0]) + ';';
+    m_animate_values[3] = "values=\"" + std::to_string(delta[1]) + ';';
+  } else {
+    m_animate_times += std::to_string(time / m_time_span) + ';';
+    m_animate_values[0] += std::to_string(min[0]) + ';';
+    m_animate_values[1] += std::to_string(min[1]) + ';';
+    m_animate_values[2] += std::to_string(delta[0]) + ';';
+    m_animate_values[3] += std::to_string(delta[1]) + ';';
+  }
+}
+
+void BackendSVG::end_animated_rect() {
+
+  m_animate_times.back() = '\"';
+  for (int i = 0; i < 3; ++i) {
+    m_animate_values[i].back() = '\"';
+  }
+  const std::string names[3] = {"cx", "cy", "r"};
+  for (int i = 0; i < 3; ++i) {
+    m_out << "<animate attributeName=\"" + names[i] +
+                 "\" repeatCount=\"indefinite\" begin =\"0s\" dur=\""
+          << m_time_span << "s\" " << m_animate_values[i] << ' '
+          << m_animate_times << "/>\n";
+  }
+  circle_end();
+  m_animate_times.clear();
+
+  for (int i = 0; i < 3; ++i) {
+    m_animate_values[i].clear();
+  }
 }
 
 void BackendSVG::circle_begin(const vfloat2_t &centre, const float r) noexcept {

--- a/src/backend/BackendSVG.cpp
+++ b/src/backend/BackendSVG.cpp
@@ -122,15 +122,14 @@ void BackendSVG::rect(const bfloat2_t &x, const float r) noexcept {
   rect_end();
 }
 
-void BackendSVG::add_animated_rect(const bfloat2_t &x, const float r,
-                                   float time) {
+void BackendSVG::add_animated_rect(const bfloat2_t &x, float time) {
 
   const auto &delta = x.delta();
   vfloat2_t min = x.min();
 
   // check if first rect
   if (m_animate_times.empty()) {
-    rect_begin(x, r);
+    rect_begin(x, 0.f);
 
     if (m_animate_values.size() < 4) {
       m_animate_values.resize(4);

--- a/src/backend/BackendSVG.hpp
+++ b/src/backend/BackendSVG.hpp
@@ -101,13 +101,21 @@ class BackendSVG {
   /// Add the closing circle tag to m_out
   void circle_end() noexcept;
 
+  /// Add the opening rect tag to m_out
+  ///
+  /// @param x the bounding box of the rectangle
+  /// @param r the radius of the circle used to round the corners
+  void rect_begin(const bfloat2_t &x, float r) noexcept;
+
+  /// Add the closing rect tag to m_out
+  void rect_end() noexcept;
+
 public:
   explicit BackendSVG(std::ostream &out) : m_out(out) {
     stroke_color({0, 0, 0, 255});
     fill_color({0, 0, 0, 255});
     stroke_width(1);
   }
-
 
   void init(float width, float height, float time_span,
             const char *name) noexcept;
@@ -180,6 +188,18 @@ public:
   /// @param x the bounding box of the rectangle
   /// @param r the radius of the circle used to round the corners, default 0.f
   void rect(const bfloat2_t &x, float r = 0.f) noexcept;
+
+  /// start/continue an animated rectangle, optimally with rounded corners.
+  /// subsequent calls to this method will add extra keyframe to the animation.
+  ///
+  /// @param x the bounding box of the rectangle
+  /// @param r the radius of the circle used to round the corners, default 0.f
+  /// @param time the time of the keyframe
+  void add_animated_rect(const bfloat2_t &x, float r = 0.f, float time);
+
+  /// end an animated rectangle
+  ///
+  void end_animated_rect();
 
   /// draw a circle
   ///

--- a/src/backend/BackendSVG.hpp
+++ b/src/backend/BackendSVG.hpp
@@ -195,7 +195,7 @@ public:
   /// @param x the bounding box of the rectangle
   /// @param r the radius of the circle used to round the corners, default 0.f
   /// @param time the time of the keyframe
-  void add_animated_rect(const bfloat2_t &x, float r = 0.f, float time);
+  void add_animated_rect(const bfloat2_t &x, float time);
 
   /// end an animated rectangle
   ///

--- a/src/frontend/Axis.cpp
+++ b/src/frontend/Axis.cpp
@@ -45,9 +45,11 @@ Axis::Axis(Figure &figure, const bfloat2_t &area)
 std::shared_ptr<Plot1D> Axis::plot(int n) { return m_plot1d.at(n); }
 
 std::shared_ptr<Plot1D> Axis::plot_impl(const std::shared_ptr<Plot1D> &plot,
+                                        const Transform &transform,
                                         const DataWithAesthetic &values) {
   m_plot1d.emplace_back(plot);
   m_children.push_back(m_plot1d.back().get());
+  m_plot1d.back()->set_transform(transform);
   m_plot1d.back()->add_frame(values, 0);
   m_plot1d.back()->set_color(RGBA::defaults[m_plot1d.size() - 1]);
   m_plot1d.back()->resize(m_pixels);

--- a/src/frontend/Axis.cpp
+++ b/src/frontend/Axis.cpp
@@ -44,15 +44,12 @@ Axis::Axis(Figure &figure, const bfloat2_t &area)
 
 std::shared_ptr<Plot1D> Axis::plot(int n) { return m_plot1d.at(n); }
 
-std::shared_ptr<Plot1D>
-Axis::plot_impl(const std::shared_ptr<Plot1D> &plot,
-                const std::shared_ptr<DataWithAesthetic> &values,
-                const std::string &label) {
+std::shared_ptr<Plot1D> Axis::plot_impl(const std::shared_ptr<Plot1D> &plot,
+                                        const DataWithAesthetic &values) {
   m_plot1d.emplace_back(plot);
   m_children.push_back(m_plot1d.back().get());
   m_plot1d.back()->add_frame(values, 0);
   m_plot1d.back()->set_color(RGBA::defaults[m_plot1d.size() - 1]);
-  m_plot1d.back()->set_label(label);
   m_plot1d.back()->resize(m_pixels);
   return m_plot1d.back();
 }

--- a/src/frontend/Axis.hpp
+++ b/src/frontend/Axis.hpp
@@ -119,46 +119,39 @@ public:
   /// \return shared pointer to the new plot
   template <typename T1, typename T2>
   std::shared_ptr<Plot1D> plot(const std::vector<T1> &x,
-                               const std::vector<T2> &y,
-                               const std::string &label = std::string()) {
+                               const std::vector<T2> &y) {
     if (x.size() != y.size()) {
       throw Exception("x and y vector sizes do not match");
     }
-    auto data = std::make_shared<DataWithAesthetic>();
-    data->set(Aesthetic::x(), x);
-    data->set(Aesthetic::y(), y);
-    return plot_impl(std::make_shared<Line>(*this), data, label);
+    return plot_impl(std::make_shared<Line>(*this),
+                     DataWithAesthetic().x(x).y(y));
   }
 
   /// Create a new Points plot and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
   /// \return shared pointer to the new plot
   std::shared_ptr<Plot1D>
-  points(const std::shared_ptr<DataWithAesthetic> &data,
-         const Transform &transform = Transform(Identity()),
-         const std::string &label = std::string()) {
-    return plot_impl(std::make_shared<Points>(*this), transform(data), label);
+  points(const DataWithAesthetic &data,
+         const Transform &transform = Transform(Identity())) {
+    return plot_impl(std::make_shared<Points>(*this), transform(data));
   }
 
   /// Create a new Line and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
   /// \return shared pointer to the new plot
   std::shared_ptr<Plot1D>
-  line(const std::shared_ptr<DataWithAesthetic> &data,
-       const Transform &transform = Transform(Identity()),
-       const std::string &label = std::string()) {
-    return plot_impl(std::make_shared<Line>(*this), transform(data), label);
+  line(const DataWithAesthetic &data,
+       const Transform &transform = Transform(Identity())) {
+    return plot_impl(std::make_shared<Line>(*this), transform(data));
   }
 
   /// Create a new histogram and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
   /// \return shared pointer to the new plot
   std::shared_ptr<Plot1D>
-  histogram(const std::shared_ptr<DataWithAesthetic> &data,
-            const Transform &transform = Transform(BinX()),
-            const std::string &label = std::string()) {
-    return plot_impl(std::make_shared<Histogram>(*this), transform(data),
-                     label);
+  histogram(const DataWithAesthetic &data,
+            const Transform &transform = Transform(BinX())) {
+    return plot_impl(std::make_shared<Histogram>(*this), transform(data));
   }
 
   /// Return a shared pointer to an existing plot.
@@ -180,10 +173,8 @@ public:
   void font_face(const std::string &fontFace) { m_font_face = fontFace; }
 
 private:
-  std::shared_ptr<Plot1D>
-  plot_impl(const std::shared_ptr<Plot1D> &plot,
-            const std::shared_ptr<DataWithAesthetic> &values,
-            const std::string &label);
+  std::shared_ptr<Plot1D> plot_impl(const std::shared_ptr<Plot1D> &plot,
+                                    const DataWithAesthetic &values);
 
   void update_tick_information();
   vfloat2_t calculate_num_ticks();

--- a/src/frontend/Axis.hpp
+++ b/src/frontend/Axis.hpp
@@ -45,6 +45,7 @@ class Axis;
 #include "frontend/Data.hpp"
 #include "frontend/Drawable.hpp"
 #include "frontend/Figure.hpp"
+#include "frontend/Histogram.hpp"
 #include "frontend/Line.hpp"
 #include "frontend/Points.hpp"
 #include "util/Colors.hpp"
@@ -132,17 +133,32 @@ public:
   /// Create a new Points plot and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
   /// \return shared pointer to the new plot
-  std::shared_ptr<Plot1D> points(const std::shared_ptr<DataWithAesthetic> &data,
-                                 const std::string &label = std::string()) {
-    return plot_impl(std::make_shared<Points>(*this), data, label);
+  std::shared_ptr<Plot1D>
+  points(const std::shared_ptr<DataWithAesthetic> &data,
+         const Transform &transform = Transform(Identity()),
+         const std::string &label = std::string()) {
+    return plot_impl(std::make_shared<Points>(*this), transform(data), label);
   }
 
   /// Create a new Line and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
   /// \return shared pointer to the new plot
-  std::shared_ptr<Plot1D> line(const std::shared_ptr<DataWithAesthetic> &data,
-                               const std::string &label = std::string()) {
-    return plot_impl(std::make_shared<Line>(*this), data, label);
+  std::shared_ptr<Plot1D>
+  line(const std::shared_ptr<DataWithAesthetic> &data,
+       const Transform &transform = Transform(Identity()),
+       const std::string &label = std::string()) {
+    return plot_impl(std::make_shared<Line>(*this), transform(data), label);
+  }
+
+  /// Create a new histogram and return a shared pointer to it.
+  /// \param data the `DataWithAesthetic` dataset to use
+  /// \return shared pointer to the new plot
+  std::shared_ptr<Plot1D>
+  histogram(const std::shared_ptr<DataWithAesthetic> &data,
+            const Transform &transform = Transform(BinX()),
+            const std::string &label = std::string()) {
+    return plot_impl(std::make_shared<Histogram>(*this), transform(data),
+                     label);
   }
 
   /// Return a shared pointer to an existing plot.

--- a/src/frontend/Axis.hpp
+++ b/src/frontend/Axis.hpp
@@ -123,7 +123,7 @@ public:
     if (x.size() != y.size()) {
       throw Exception("x and y vector sizes do not match");
     }
-    return plot_impl(std::make_shared<Line>(*this),
+    return plot_impl(std::make_shared<Line>(*this), Transform(Identity()),
                      DataWithAesthetic().x(x).y(y));
   }
 
@@ -133,7 +133,7 @@ public:
   std::shared_ptr<Plot1D>
   points(const DataWithAesthetic &data,
          const Transform &transform = Transform(Identity())) {
-    return plot_impl(std::make_shared<Points>(*this), transform(data));
+    return plot_impl(std::make_shared<Points>(*this), transform, data);
   }
 
   /// Create a new Line and return a shared pointer to it.
@@ -142,7 +142,7 @@ public:
   std::shared_ptr<Plot1D>
   line(const DataWithAesthetic &data,
        const Transform &transform = Transform(Identity())) {
-    return plot_impl(std::make_shared<Line>(*this), transform(data));
+    return plot_impl(std::make_shared<Line>(*this), transform, data);
   }
 
   /// Create a new histogram and return a shared pointer to it.
@@ -151,7 +151,7 @@ public:
   std::shared_ptr<Plot1D>
   histogram(const DataWithAesthetic &data,
             const Transform &transform = Transform(BinX())) {
-    return plot_impl(std::make_shared<Histogram>(*this), transform(data));
+    return plot_impl(std::make_shared<Histogram>(*this), transform, data);
   }
 
   /// Return a shared pointer to an existing plot.
@@ -174,6 +174,7 @@ public:
 
 private:
   std::shared_ptr<Plot1D> plot_impl(const std::shared_ptr<Plot1D> &plot,
+                                    const Transform &transform,
                                     const DataWithAesthetic &values);
 
   void update_tick_information();

--- a/src/frontend/Axis.hpp
+++ b/src/frontend/Axis.hpp
@@ -129,6 +129,7 @@ public:
 
   /// Create a new Points plot and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
+  /// \param transform (optional) the transform to apply
   /// \return shared pointer to the new plot
   std::shared_ptr<Plot1D>
   points(const DataWithAesthetic &data,
@@ -138,6 +139,7 @@ public:
 
   /// Create a new Line and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
+  /// \param transform (optional) the transform to apply
   /// \return shared pointer to the new plot
   std::shared_ptr<Plot1D>
   line(const DataWithAesthetic &data,
@@ -147,6 +149,7 @@ public:
 
   /// Create a new histogram and return a shared pointer to it.
   /// \param data the `DataWithAesthetic` dataset to use
+  /// \param transform (optional) the transform to apply
   /// \return shared pointer to the new plot
   std::shared_ptr<Plot1D>
   histogram(const DataWithAesthetic &data,
@@ -163,9 +166,14 @@ public:
   template <typename Backend> void serialise(Backend &backend);
   template <typename Backend> void draw(Backend &backend, float time);
 
+  /// convert from display coordinates to data coordinates, using the given
+  /// Aesthetic
   template <typename Aesthetic> float from_display(const float i) const {
     return Aesthetic::from_display(i, m_limits, m_pixels);
   }
+
+  /// convert from data coordinates to display coordinates, using the given
+  /// Aesthetic
   template <typename Aesthetic> float to_display(const float i) const {
     return Aesthetic::to_display(i, m_limits, m_pixels);
   }
@@ -173,6 +181,16 @@ public:
   void font_face(const std::string &fontFace) { m_font_face = fontFace; }
 
 private:
+  /// Create a new Plot1D on this axis and return a shared pointer to it.
+  ///
+  /// All the plotting functions go through this function, which does the actual
+  /// work of adding the new Plot1D, its data and transform to the axis. A
+  /// default color is given to the new plot based on the number of already
+  /// existing plots (see Colors.hpp for list of default colors)
+  ///
+  /// \param data the `DataWithAesthetic` dataset to use
+  /// \param transform the transform to apply
+  /// \return shared pointer to the new plot
   std::shared_ptr<Plot1D> plot_impl(const std::shared_ptr<Plot1D> &plot,
                                     const Transform &transform,
                                     const DataWithAesthetic &values);

--- a/src/frontend/AxisDraw.hpp
+++ b/src/frontend/AxisDraw.hpp
@@ -37,6 +37,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "backend/Backend.hpp"
 #include "frontend/Axis.hpp"
 #include "frontend/Geometry.hpp"
+#include "frontend/HistogramDraw.hpp"
+#include "frontend/LineDraw.hpp"
+#include "frontend/PointsDraw.hpp"
 
 namespace trase {
 

--- a/src/frontend/Data.cpp
+++ b/src/frontend/Data.cpp
@@ -35,25 +35,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace trase {
 
-ColumnIterator RawData::begin(const int i) {
+ColumnIterator RawData::begin(const int i) const {
   if (i < 0 || i >= cols()) {
     throw std::out_of_range("column does not exist");
   }
-  return {m_matrix.begin() + i, m_cols};
+  return {m_matrix.cbegin() + i, m_cols};
 }
 
-ColumnIterator RawData::end(const int i) {
+ColumnIterator RawData::end(const int i) const {
   if (i < 0 || i >= cols()) {
     throw std::out_of_range("column does not exist");
   }
-  return {m_matrix.end() + i, m_cols};
+  return {m_matrix.cend() + i, m_cols};
 }
 
 int DataWithAesthetic::rows() const { return m_data->rows(); }
 
-const Limits &DataWithAesthetic::limits() { return m_limits; }
+const Limits &DataWithAesthetic::limits() const { return m_limits; }
 
-template <typename Aesthetic> ColumnIterator DataWithAesthetic::begin() {
+template <typename Aesthetic> ColumnIterator DataWithAesthetic::begin() const {
 
   auto search = m_map.find(Aesthetic::index);
 
@@ -63,7 +63,7 @@ template <typename Aesthetic> ColumnIterator DataWithAesthetic::begin() {
   return m_data->begin(search->second);
 }
 
-template <typename Aesthetic> ColumnIterator DataWithAesthetic::end() {
+template <typename Aesthetic> ColumnIterator DataWithAesthetic::end() const {
 
   auto search = m_map.find(Aesthetic::index);
 
@@ -73,15 +73,15 @@ template <typename Aesthetic> ColumnIterator DataWithAesthetic::end() {
   return m_data->end(search->second);
 }
 
-template ColumnIterator DataWithAesthetic::begin<Aesthetic::x>();
-template ColumnIterator DataWithAesthetic::begin<Aesthetic::y>();
-template ColumnIterator DataWithAesthetic::begin<Aesthetic::color>();
-template ColumnIterator DataWithAesthetic::begin<Aesthetic::size>();
+template ColumnIterator DataWithAesthetic::begin<Aesthetic::x>() const;
+template ColumnIterator DataWithAesthetic::begin<Aesthetic::y>() const;
+template ColumnIterator DataWithAesthetic::begin<Aesthetic::color>() const;
+template ColumnIterator DataWithAesthetic::begin<Aesthetic::size>() const;
 
-template ColumnIterator DataWithAesthetic::end<Aesthetic::x>();
-template ColumnIterator DataWithAesthetic::end<Aesthetic::y>();
-template ColumnIterator DataWithAesthetic::end<Aesthetic::color>();
-template ColumnIterator DataWithAesthetic::end<Aesthetic::size>();
+template ColumnIterator DataWithAesthetic::end<Aesthetic::x>() const;
+template ColumnIterator DataWithAesthetic::end<Aesthetic::y>() const;
+template ColumnIterator DataWithAesthetic::end<Aesthetic::color>() const;
+template ColumnIterator DataWithAesthetic::end<Aesthetic::size>() const;
 
 const int Aesthetic::N;
 const int Aesthetic::x::index;

--- a/src/frontend/Data.cpp
+++ b/src/frontend/Data.cpp
@@ -168,4 +168,30 @@ float Aesthetic::size::from_display(const float display, const Limits &data_lim,
   return data_lim.bmin[index] + rel_pos * len_ratio;
 }
 
+template <typename Aesthetic>
+void DataWithAesthetic::set(const float min, const float max) {
+  m_limits.bmin[Aesthetic::index] = min;
+  m_limits.bmax[Aesthetic::index] = max;
+}
+
+DataWithAesthetic &DataWithAesthetic::x(const float min, const float max) {
+  set<Aesthetic::x>(min, max);
+  return *this;
+}
+
+DataWithAesthetic &DataWithAesthetic::y(const float min, const float max) {
+  set<Aesthetic::y>(min, max);
+  return *this;
+}
+
+DataWithAesthetic &DataWithAesthetic::color(const float min, const float max) {
+  set<Aesthetic::color>(min, max);
+  return *this;
+}
+
+DataWithAesthetic &DataWithAesthetic::size(const float min, const float max) {
+  set<Aesthetic::size>(min, max);
+  return *this;
+}
+
 } // namespace trase

--- a/src/frontend/Data.hpp
+++ b/src/frontend/Data.hpp
@@ -171,6 +171,12 @@ public:
   template <typename Aesthetic, typename T>
   void set(const std::vector<T> &data);
 
+  /// rather than adding new data, this allows the limits of a given aesthetic
+  /// to be manually set. This is used, for example, with geometries where the
+  /// data is implicitly defined over a range (e.g. histograms with regular bin
+  /// widths)
+  template <typename Aesthetic> void set(float min, float max);
+
   /// returns number of rows in the data let
   int rows() const;
 
@@ -178,12 +184,16 @@ public:
   const Limits &limits() const;
 
   template <typename T> DataWithAesthetic &x(const std::vector<T> &data);
+  DataWithAesthetic &x(float min, float max);
 
   template <typename T> DataWithAesthetic &y(const std::vector<T> &data);
+  DataWithAesthetic &y(float min, float max);
 
   template <typename T> DataWithAesthetic &color(const std::vector<T> &data);
+  DataWithAesthetic &color(float min, float max);
 
   template <typename T> DataWithAesthetic &size(const std::vector<T> &data);
+  DataWithAesthetic &size(float min, float max);
 };
 
 } // namespace trase

--- a/src/frontend/Data.hpp
+++ b/src/frontend/Data.hpp
@@ -60,20 +60,24 @@ class RawData {
 
 public:
   /// return the number of columns
-  int cols() { return m_cols; };
+  int cols() const { return m_cols; };
 
   /// return the number of rows
-  int rows() { return m_rows; };
+  int rows() const { return m_rows; };
 
   /// add a new column to the matrix. the data in `new_col` is copied into the
   /// new column
   template <typename T> void add_column(const std::vector<T> &new_col);
 
+  /// set a column in the matrix. the data in `new_col` is copied into column i
+  template <typename T>
+  void set_column(const int i, const std::vector<T> &new_col);
+
   /// return a ColumnIterator to the beginning of column i
-  ColumnIterator begin(int i);
+  ColumnIterator begin(int i) const;
 
   /// return a ColumnIterator to the end of column i
-  ColumnIterator end(int i);
+  ColumnIterator end(int i) const;
 };
 
 /// Aesthetics are a collection of tag classes that represent each aesthetic
@@ -155,24 +159,24 @@ public:
 
   /// return a ColumnIterator to the beginning of the data column for aesthetic
   /// a, throws if a has not yet been set
-  template <typename Aesthetic> ColumnIterator begin();
+  template <typename Aesthetic> ColumnIterator begin() const;
 
   /// return a ColumnIterator to the end of the data column for aesthetic a,
   /// throws if a has not yet been set
-  template <typename Aesthetic> ColumnIterator end();
+  template <typename Aesthetic> ColumnIterator end() const;
 
   /// if aesthetic a is not yet been set, this creates a new data column and
   /// copies in `data` (throws if data does not have the correct number of
   /// rows). If aesthetic a has been previously set, its data column is
   /// overwritten with `data`
   template <typename Aesthetic, typename T>
-  void set(const Aesthetic &a, const std::vector<T> &data);
+  void set(const std::vector<T> &data);
 
   /// returns number of rows in the data let
   int rows() const;
 
   /// returns the min/max limits of the data
-  const Limits &limits();
+  const Limits &limits() const;
 
   template <typename T> DataWithAesthetic &x(const std::vector<T> &data);
 

--- a/src/frontend/Data.hpp
+++ b/src/frontend/Data.hpp
@@ -70,8 +70,7 @@ public:
   template <typename T> void add_column(const std::vector<T> &new_col);
 
   /// set a column in the matrix. the data in `new_col` is copied into column i
-  template <typename T>
-  void set_column(const int i, const std::vector<T> &new_col);
+  template <typename T> void set_column(int i, const std::vector<T> &new_col);
 
   /// return a ColumnIterator to the beginning of column i
   ColumnIterator begin(int i) const;

--- a/src/frontend/Data.tcc
+++ b/src/frontend/Data.tcc
@@ -84,7 +84,7 @@ void RawData::set_column(const int i, const std::vector<T> &new_col) {
 
   // copy column
   for (int j = 0; j < m_rows; ++j) {
-    m_matrix[j * m_cols + i] = new_col[j];
+    m_matrix[j * m_cols + i] = static_cast<float>(new_col[j]);
   }
 }
 

--- a/src/frontend/Data.tcc
+++ b/src/frontend/Data.tcc
@@ -73,7 +73,7 @@ template <typename T>
 void RawData::set_column(const int i, const std::vector<T> &new_col) {
 
   // check column exists
-  if (i < 0 || i > cols()) {
+  if (i < 0 || i >= cols()) {
     throw std::out_of_range("column index out of range");
   }
 

--- a/src/frontend/Geometry.hpp
+++ b/src/frontend/Geometry.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GEOMETRY_H_
 #define GEOMETRY_H_
 
+#include "frontend/Histogram.hpp"
 #include "frontend/Line.hpp"
 #include "frontend/Plot1D.hpp"
 #include "frontend/Points.hpp"
@@ -49,6 +50,8 @@ void serialise_geometry(std::shared_ptr<Plot1D> &plot, Backend &backend) {
     points->serialise(backend);
   } else if (auto line = dynamic_cast<Line *>(plot.get())) {
     line->serialise(backend);
+  } else if (auto histogram = dynamic_cast<Histogram *>(plot.get())) {
+    histogram->serialise(backend);
   } else {
     throw Exception("unknown geometry class");
   }
@@ -61,6 +64,8 @@ void draw_geometry(std::shared_ptr<Plot1D> &plot, Backend &backend,
     points->draw(backend, time);
   } else if (auto line = dynamic_cast<Line *>(plot.get())) {
     line->draw(backend, time);
+  } else if (auto histogram = dynamic_cast<Histogram *>(plot.get())) {
+    histogram->draw(backend, time);
   } else {
     throw Exception("unknown geometry class");
   }

--- a/src/frontend/Histogram.cpp
+++ b/src/frontend/Histogram.cpp
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2018, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of trase.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "frontend/Histogram.hpp"
+
+namespace trase {} // namespace trase

--- a/src/frontend/Histogram.hpp
+++ b/src/frontend/Histogram.hpp
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2018, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of trase.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef HISTOGRAM_H_
+#define HISTOGRAM_H_
+
+#include "frontend/Plot1D.hpp"
+
+namespace trase {
+
+class Histogram : public Plot1D {
+public:
+  explicit Histogram(Axis &axis) : Plot1D(axis) {}
+  template <typename Backend> void serialise(Backend &backend);
+  template <typename Backend> void draw(Backend &backend, float time);
+
+private:
+  template <typename Backend> void serialise_frames(Backend &backend);
+  template <typename Backend> void serialise_highlights(Backend &backend);
+  template <typename Backend> void draw_plot(Backend &backend);
+  template <typename Backend> void draw_highlights(Backend &backend);
+};
+
+} // namespace trase
+
+#endif // LINE_H_

--- a/src/frontend/HistogramDraw.hpp
+++ b/src/frontend/HistogramDraw.hpp
@@ -60,10 +60,12 @@ template <typename Backend> void Histogram::serialise_frames(Backend &backend) {
   for (int i = 0; i < m_data[0].rows(); ++i) {
     for (size_t f = 0; f < m_times.size(); ++f) {
       auto y_data = m_data[f].begin<Aesthetic::y>()[i];
-      auto y_max = m_axis.to_display<Aesthetic::y>(y_data);
-      auto y_min = m_axis.to_display<Aesthetic::y>(0.f);
+      auto y_min = m_axis.to_display<Aesthetic::y>(y_data);
+      auto y_max = m_axis.to_display<Aesthetic::y>(0.f);
       auto x_min = (i - 0.5f) * dx + x0;
       auto x_max = (i + 0.5f) * dx + x0;
+      std::cout << "adding rect with "
+                << bfloat2_t({x_min, y_min}, {x_max, y_max}) << std::endl;
       backend.add_animated_rect(bfloat2_t({x_min, y_min}, {x_max, y_max}),
                                 m_times[f]);
     }
@@ -93,8 +95,9 @@ template <typename Backend> void Histogram::draw_plot(Backend &backend) {
     for (int i = 0; i < m_data[0].rows(); ++i) {
       auto x_min = (i - 0.5f) * dx + x0;
       auto x_max = (i + 0.5f) * dx + x0;
-      auto y = m_axis.to_display<Aesthetic::y>(y_data[i]);
-      backend.rect(bfloat2_t({x_min, 0.f}, {x_max, y}));
+      auto y_min = m_axis.to_display<Aesthetic::y>(y_data[i]);
+      auto y_max = m_axis.to_display<Aesthetic::y>(0.f);
+      backend.rect(bfloat2_t({x_min, y_min}, {x_max, y_max}));
     }
   } else {
     auto y0 = m_data[f - 1].begin<Aesthetic::y>();
@@ -102,9 +105,9 @@ template <typename Backend> void Histogram::draw_plot(Backend &backend) {
     for (int i = 0; i < m_data[0].rows(); ++i) {
       auto x_min = (i - 0.5f) * dx + x0;
       auto x_max = (i + 0.5f) * dx + x0;
-      auto y_min = m_axis.to_display<Aesthetic::y>(0.f);
-      auto y_max = w1 * m_axis.to_display<Aesthetic::y>(y1[i]) +
+      auto y_min = w1 * m_axis.to_display<Aesthetic::y>(y1[i]) +
                    w2 * m_axis.to_display<Aesthetic::y>(y0[i]);
+      auto y_max = m_axis.to_display<Aesthetic::y>(0.f);
       backend.rect(bfloat2_t({x_min, y_min}, {x_max, y_max}));
     }
   }

--- a/src/frontend/HistogramDraw.hpp
+++ b/src/frontend/HistogramDraw.hpp
@@ -51,19 +51,19 @@ template <typename Backend> void Histogram::serialise_frames(Backend &backend) {
   backend.stroke_width(m_line_width);
   backend.fill_color(m_color);
 
-  // x should be constant and regular spaced
-  auto x_begin = m_data[0].begin<Aesthetic::x>();
-  const float x0 = m_axis.to_display<Aesthetic::x>(x_begin[0]);
-  const float x1 = m_axis.to_display<Aesthetic::x>(x_begin[1]);
-  const float dx = x1 - x0;
+  // x should be constant and regular spaced with a dx calculated by the limits
+  // and the number of rows
+  const float x0 = m_data[0].limits().bmin[Aesthetic::x::index];
+  const float dx =
+      (m_data[0].limits().bmax[Aesthetic::x::index] - x0) / m_data[0].rows();
 
   for (int i = 0; i < m_data[0].rows(); ++i) {
     for (size_t f = 0; f < m_times.size(); ++f) {
       auto y_data = m_data[f].begin<Aesthetic::y>()[i];
       auto y_min = m_axis.to_display<Aesthetic::y>(y_data);
       auto y_max = m_axis.to_display<Aesthetic::y>(0.f);
-      auto x_min = (i - 0.5f) * dx + x0;
-      auto x_max = (i + 0.5f) * dx + x0;
+      auto x_min = m_axis.to_display<Aesthetic::x>(i * dx + x0);
+      auto x_max = m_axis.to_display<Aesthetic::x>((i + 1.f) * dx + x0);
       std::cout << "adding rect with "
                 << bfloat2_t({x_min, y_min}, {x_max, y_max}) << std::endl;
       backend.add_animated_rect(bfloat2_t({x_min, y_min}, {x_max, y_max}),
@@ -83,18 +83,18 @@ template <typename Backend> void Histogram::draw_plot(Backend &backend) {
   backend.stroke_width(m_line_width);
   backend.fill_color(m_color);
 
-  // x should be constant and regular spaced
-  auto x_begin = m_data[0].begin<Aesthetic::x>();
-  const float x0 = m_axis.to_display<Aesthetic::x>(x_begin[0]);
-  const float x1 = m_axis.to_display<Aesthetic::x>(x_begin[1]);
-  const float dx = x1 - x0;
+  // x should be constant and regular spaced with a dx calculated by the limits
+  // and the number of rows
+  const float x0 = m_data[0].limits().bmin[Aesthetic::x::index];
+  const float dx =
+      (m_data[0].limits().bmax[Aesthetic::x::index] - x0) / m_data[0].rows();
 
   if (w2 == 0.0f) {
     // exactly on a single frame
     auto y_data = m_data[f].begin<Aesthetic::y>();
     for (int i = 0; i < m_data[0].rows(); ++i) {
-      auto x_min = (i - 0.5f) * dx + x0;
-      auto x_max = (i + 0.5f) * dx + x0;
+      auto x_min = m_axis.to_display<Aesthetic::x>(i * dx + x0);
+      auto x_max = m_axis.to_display<Aesthetic::x>((i + 1.f) * dx + x0);
       auto y_min = m_axis.to_display<Aesthetic::y>(y_data[i]);
       auto y_max = m_axis.to_display<Aesthetic::y>(0.f);
       backend.rect(bfloat2_t({x_min, y_min}, {x_max, y_max}));
@@ -103,8 +103,8 @@ template <typename Backend> void Histogram::draw_plot(Backend &backend) {
     auto y0 = m_data[f - 1].begin<Aesthetic::y>();
     auto y1 = m_data[f].begin<Aesthetic::y>();
     for (int i = 0; i < m_data[0].rows(); ++i) {
-      auto x_min = (i - 0.5f) * dx + x0;
-      auto x_max = (i + 0.5f) * dx + x0;
+      auto x_min = m_axis.to_display<Aesthetic::x>(i * dx + x0);
+      auto x_max = m_axis.to_display<Aesthetic::x>((i + 1.f) * dx + x0);
       auto y_min = w1 * m_axis.to_display<Aesthetic::y>(y1[i]) +
                    w2 * m_axis.to_display<Aesthetic::y>(y0[i]);
       auto y_max = m_axis.to_display<Aesthetic::y>(0.f);

--- a/src/frontend/HistogramDraw.hpp
+++ b/src/frontend/HistogramDraw.hpp
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2018, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of trase.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "frontend/Histogram.hpp"
+
+namespace trase {
+
+template <typename Backend> void Histogram::serialise(Backend &backend) {
+  serialise_frames(backend);
+}
+
+template <typename Backend>
+void Histogram::draw(Backend &backend, const float time) {
+  update_frame_info(time);
+  draw_plot(backend);
+}
+
+template <typename Backend> void Histogram::serialise_frames(Backend &backend) {
+
+  backend.stroke_color(m_color);
+  backend.stroke_width(m_line_width);
+  backend.fill_color(m_fill_color);
+
+  // x should be constant and regular spaced
+  auto x_begin = m_data[0]->begin<Aesthetic::x>();
+  auto x_end = m_data[0]->end<Aesthetic::x>();
+  const float min = m_axis.to_display<Aesthetic::x>(*x_begin);
+  const float dx = m_axis.to_display<Aesthetic::x>(x_begin[1] - x_begin[0]);
+
+  for (int i = 0; i < m_data[0]->rows(); ++i) {
+    for (size_t f = 0; f < m_times.size(); ++f) {
+      auto y_data = m_data[f]->begin<Aesthetic::y>()[i];
+      auto y = m_axis.to_display<Aesthetic::y>(y_data);
+      auto x_min = (i - 0.5f) * dx;
+      auto x_max = (i + 0.5f) * dx;
+      backend.add_animated_rect(bfloat2_t({x_min, 0.f}, {x_max, y}),
+                                m_times[f]);
+    }
+    backend.end_animated_rect();
+  }
+}
+
+template <typename Backend> void Histogram::draw_plot(Backend &backend) {
+
+  const int f = m_frame_info.frame_above;
+  const float w1 = m_frame_info.w1;
+  const float w2 = m_frame_info.w2;
+
+  backend.stroke_color(m_color);
+  backend.stroke_width(m_line_width);
+  backend.fill_color(m_fill_color);
+
+  // x should be constant and regular spaced
+  auto x_begin = m_data[0]->begin<Aesthetic::x>();
+  auto x_end = m_data[0]->end<Aesthetic::x>();
+  const float min = m_axis.to_display<Aesthetic::x>(*x_begin);
+  const float dx = m_axis.to_display<Aesthetic::x>(x_begin[1] - x_begin[0]);
+
+  if (w2 == 0.0f) {
+    // exactly on a single frame
+    auto y_data = m_data[f]->begin<Aesthetic::y>();
+    for (int i = 1; i < m_data[0]->rows(); ++i) {
+      auto x_min = (i - 0.5f) * dx;
+      auto x_max = (i + 0.5f) * dx;
+      auto y = m_axis.to_display<Aesthetic::y>(y_data[i]);
+      backend.rect(bfloat2_t({x_min, 0.f}, {x_max, y}));
+    }
+
+  } else {
+    auto y0 = m_data[f - 1]->begin<Aesthetic::y>();
+    auto y1 = m_data[f]->begin<Aesthetic::y>();
+    for (int i = 1; i < m_data[0]->rows(); ++i) {
+      auto x_min = (i - 0.5f) * dx;
+      auto x_max = (i + 0.5f) * dx;
+      auto y = w1 * m_axis.to_display<Aesthetic::y>(y1[i]) +
+               w2 * m_axis.to_display<Aesthetic::y>(y0[i]);
+      backend.rect(bfloat2_t({x_min, 0.f}, {x_max, y}));
+    }
+  }
+}
+
+} // namespace trase

--- a/src/frontend/HistogramDraw.hpp
+++ b/src/frontend/HistogramDraw.hpp
@@ -49,17 +49,17 @@ template <typename Backend> void Histogram::serialise_frames(Backend &backend) {
 
   backend.stroke_color(m_color);
   backend.stroke_width(m_line_width);
-  backend.fill_color(m_fill_color);
+  backend.fill_color(m_color);
 
   // x should be constant and regular spaced
-  auto x_begin = m_data[0]->begin<Aesthetic::x>();
-  auto x_end = m_data[0]->end<Aesthetic::x>();
+  auto x_begin = m_data[0].begin<Aesthetic::x>();
+  auto x_end = m_data[0].end<Aesthetic::x>();
   const float min = m_axis.to_display<Aesthetic::x>(*x_begin);
   const float dx = m_axis.to_display<Aesthetic::x>(x_begin[1] - x_begin[0]);
 
-  for (int i = 0; i < m_data[0]->rows(); ++i) {
+  for (int i = 0; i < m_data[0].rows(); ++i) {
     for (size_t f = 0; f < m_times.size(); ++f) {
-      auto y_data = m_data[f]->begin<Aesthetic::y>()[i];
+      auto y_data = m_data[f].begin<Aesthetic::y>()[i];
       auto y = m_axis.to_display<Aesthetic::y>(y_data);
       auto x_min = (i - 0.5f) * dx;
       auto x_max = (i + 0.5f) * dx;
@@ -78,18 +78,16 @@ template <typename Backend> void Histogram::draw_plot(Backend &backend) {
 
   backend.stroke_color(m_color);
   backend.stroke_width(m_line_width);
-  backend.fill_color(m_fill_color);
+  backend.fill_color(m_color);
 
   // x should be constant and regular spaced
-  auto x_begin = m_data[0]->begin<Aesthetic::x>();
-  auto x_end = m_data[0]->end<Aesthetic::x>();
-  const float min = m_axis.to_display<Aesthetic::x>(*x_begin);
+  auto x_begin = m_data[0].begin<Aesthetic::x>();
   const float dx = m_axis.to_display<Aesthetic::x>(x_begin[1] - x_begin[0]);
 
   if (w2 == 0.0f) {
     // exactly on a single frame
-    auto y_data = m_data[f]->begin<Aesthetic::y>();
-    for (int i = 1; i < m_data[0]->rows(); ++i) {
+    auto y_data = m_data[f].begin<Aesthetic::y>();
+    for (int i = 1; i < m_data[0].rows(); ++i) {
       auto x_min = (i - 0.5f) * dx;
       auto x_max = (i + 0.5f) * dx;
       auto y = m_axis.to_display<Aesthetic::y>(y_data[i]);
@@ -97,9 +95,9 @@ template <typename Backend> void Histogram::draw_plot(Backend &backend) {
     }
 
   } else {
-    auto y0 = m_data[f - 1]->begin<Aesthetic::y>();
-    auto y1 = m_data[f]->begin<Aesthetic::y>();
-    for (int i = 1; i < m_data[0]->rows(); ++i) {
+    auto y0 = m_data[f - 1].begin<Aesthetic::y>();
+    auto y1 = m_data[f].begin<Aesthetic::y>();
+    for (int i = 1; i < m_data[0].rows(); ++i) {
       auto x_min = (i - 0.5f) * dx;
       auto x_max = (i + 0.5f) * dx;
       auto y = w1 * m_axis.to_display<Aesthetic::y>(y1[i]) +

--- a/src/frontend/LineDraw.hpp
+++ b/src/frontend/LineDraw.hpp
@@ -58,20 +58,20 @@ template <typename Backend> void Line::serialise_frames(Backend &backend) {
                      m_axis.to_display<Aesthetic::y>(y)};
   };
 
-  auto x = m_data[0]->begin<Aesthetic::x>();
-  auto y = m_data[0]->begin<Aesthetic::y>();
+  auto x = m_data[0].begin<Aesthetic::x>();
+  auto y = m_data[0].begin<Aesthetic::y>();
   backend.move_to(to_pixel(x[0], y[0]));
-  for (int i = 1; i < m_data[0]->rows(); ++i) {
+  for (int i = 1; i < m_data[0].rows(); ++i) {
     backend.line_to(to_pixel(x[i], y[i]));
   }
 
   // other frames
   for (size_t f = 1; f < m_times.size(); ++f) {
-    auto x = m_data[f]->begin<Aesthetic::x>();
-    auto y = m_data[f]->begin<Aesthetic::y>();
+    auto x = m_data[f].begin<Aesthetic::x>();
+    auto y = m_data[f].begin<Aesthetic::y>();
     backend.add_animated_path(m_times[f - 1]);
     backend.move_to(to_pixel(x[0], y[0]));
-    for (int i = 1; i < m_data[0]->rows(); ++i) {
+    for (int i = 1; i < m_data[0].rows(); ++i) {
       backend.line_to(to_pixel(x[i], y[i]));
     }
   }
@@ -89,9 +89,9 @@ template <typename Backend> void Line::serialise_highlights(Backend &backend) {
     backend.stroke_color(RGBA(0, 0, 0, 0));
     backend.fill_color(color, m_color);
 
-    auto x = m_data[0]->begin<Aesthetic::x>();
-    auto y = m_data[0]->begin<Aesthetic::y>();
-    for (int i = 0; i < m_data[0]->rows(); ++i) {
+    auto x = m_data[0].begin<Aesthetic::x>();
+    auto y = m_data[0].begin<Aesthetic::y>();
+    for (int i = 0; i < m_data[0].rows(); ++i) {
       vfloat2_t point = {x[i], y[i]};
       vfloat2_t point_pixel = {m_axis.to_display<Aesthetic::x>(x[i]),
                                m_axis.to_display<Aesthetic::y>(y[i])};
@@ -118,20 +118,20 @@ template <typename Backend> void Line::draw_plot(Backend &backend) {
 
   if (w2 == 0.0f) {
     // exactly on a single frame
-    auto x = m_data[f]->begin<Aesthetic::x>();
-    auto y = m_data[f]->begin<Aesthetic::y>();
+    auto x = m_data[f].begin<Aesthetic::x>();
+    auto y = m_data[f].begin<Aesthetic::y>();
     backend.move_to(to_pixel(x[0], y[0]));
-    for (int i = 1; i < m_data[0]->rows(); ++i) {
+    for (int i = 1; i < m_data[0].rows(); ++i) {
       backend.line_to(to_pixel(x[i], y[i]));
     }
   } else {
     // between two frames
-    auto x0 = m_data[f - 1]->begin<Aesthetic::x>();
-    auto y0 = m_data[f - 1]->begin<Aesthetic::y>();
-    auto x1 = m_data[f]->begin<Aesthetic::x>();
-    auto y1 = m_data[f]->begin<Aesthetic::y>();
+    auto x0 = m_data[f - 1].begin<Aesthetic::x>();
+    auto y0 = m_data[f - 1].begin<Aesthetic::y>();
+    auto x1 = m_data[f].begin<Aesthetic::x>();
+    auto y1 = m_data[f].begin<Aesthetic::y>();
     backend.move_to(w1 * to_pixel(x1[0], y1[0]) + w2 * to_pixel(x0[0], y0[0]));
-    for (int i = 1; i < m_data[0]->rows(); ++i) {
+    for (int i = 1; i < m_data[0].rows(); ++i) {
       backend.line_to(w1 * to_pixel(x1[i], y1[i]) +
                       w2 * to_pixel(x0[i], y0[i]));
     }
@@ -163,9 +163,9 @@ template <typename Backend> void Line::draw_highlights(Backend &backend) {
     float min_r2 = std::numeric_limits<float>::max();
     vfloat2_t min_point{};
     // exactly on a frame
-    auto x = m_data[m_frame_info.frame_above]->begin<Aesthetic::x>();
-    auto y = m_data[m_frame_info.frame_above]->begin<Aesthetic::y>();
-    for (int i = 0; i < m_data[0]->rows(); ++i) {
+    auto x = m_data[m_frame_info.frame_above].begin<Aesthetic::x>();
+    auto y = m_data[m_frame_info.frame_above].begin<Aesthetic::y>();
+    for (int i = 0; i < m_data[0].rows(); ++i) {
       const vfloat2_t point = {x[i], y[i]};
       auto point_r2 = (point - pos).squaredNorm();
       if (point_r2 < min_r2) {

--- a/src/frontend/Plot1D.cpp
+++ b/src/frontend/Plot1D.cpp
@@ -44,8 +44,7 @@ Plot1D::Plot1D(Axis &axis)
     : Drawable(&axis, bfloat2_t(vfloat2_t(0, 0), vfloat2_t(1, 1))),
       m_colormap(&Colormaps::viridis), m_line_width(3.f), m_axis(axis) {}
 
-void Plot1D::add_frame(const std::shared_ptr<DataWithAesthetic> &data,
-                       float time) {
+void Plot1D::add_frame(const DataWithAesthetic &data, float time) {
   // add new data frame
   m_data.push_back(data);
 
@@ -55,7 +54,7 @@ void Plot1D::add_frame(const std::shared_ptr<DataWithAesthetic> &data,
   }
 
   // update limits with new frame
-  m_limits += data->limits();
+  m_limits += data.limits();
 
   // communicate limits to parent axis
   const float buffer = 1.05f;

--- a/src/frontend/Plot1D.cpp
+++ b/src/frontend/Plot1D.cpp
@@ -46,7 +46,7 @@ Plot1D::Plot1D(Axis &axis)
 
 void Plot1D::add_frame(const DataWithAesthetic &data, float time) {
   // add new data frame
-  m_data.push_back(data);
+  m_data.push_back(m_transform(data));
 
   // add new frame time
   if (time > 0) {
@@ -54,7 +54,7 @@ void Plot1D::add_frame(const DataWithAesthetic &data, float time) {
   }
 
   // update limits with new frame
-  m_limits += data.limits();
+  m_limits += m_data.back().limits();
 
   // communicate limits to parent axis
   const float buffer = 1.05f;

--- a/src/frontend/Plot1D.hpp
+++ b/src/frontend/Plot1D.hpp
@@ -90,6 +90,14 @@ public:
     return add_frame(DataWithAesthetic().x(x).y(y), time);
   }
 
+  /// Adds a new data frame to this plot
+  ///
+  /// The limits of the new data frame will be added to the limits of this
+  /// plot, and the parent axis
+  ///
+  /// \param data the new data frame
+  /// \param time the timestamp for this frame. This must be greater than the
+  /// time for all previously added frames
   void add_frame(const DataWithAesthetic &data, float time);
 
   float get_time(const int i) const { return m_times[i]; }
@@ -98,9 +106,23 @@ public:
   DataWithAesthetic &get_data(const int i) { return m_data[i]; }
   size_t data_size() const { return m_data.size(); }
 
+  /// Sets the transform
+  ///
+  /// \param transform the new transform
+  ///
+  /// All new data frames added to the plot will have this transform applied
+  /// before the data is stored internally
   void set_transform(const Transform &transform) { m_transform = transform; }
+
   void set_color(const RGBA &color) { m_color = color; }
+
+  /// Set the label
+  ///
+  /// This label describes the plot and is shown on the axis legend
+  ///
+  /// \param label a string description of the plot
   void set_label(const std::string &label) { m_label = label; }
+
   const std::string &get_label() const { return m_label; }
   const RGBA &get_color() const { return m_color; }
   const float get_line_width() const { return m_line_width; }

--- a/src/frontend/Plot1D.hpp
+++ b/src/frontend/Plot1D.hpp
@@ -72,6 +72,9 @@ protected:
   /// parent axis
   Axis &m_axis;
 
+  /// transform
+  Transform m_transform;
+
 public:
   explicit Plot1D(Axis &axis);
 
@@ -95,6 +98,7 @@ public:
   DataWithAesthetic &get_data(const int i) { return m_data[i]; }
   size_t data_size() const { return m_data.size(); }
 
+  void set_transform(const Transform &transform) { m_transform = transform; }
   void set_color(const RGBA &color) { m_color = color; }
   void set_label(const std::string &label) { m_label = label; }
   const std::string &get_label() const { return m_label; }

--- a/src/frontend/Plot1D.hpp
+++ b/src/frontend/Plot1D.hpp
@@ -54,7 +54,7 @@ namespace trase {
 class Plot1D : public Drawable {
 protected:
   /// dataset
-  std::vector<std::shared_ptr<DataWithAesthetic>> m_data;
+  std::vector<DataWithAesthetic> m_data;
 
   /// label
   std::string m_label;
@@ -84,22 +84,15 @@ public:
     if (x.size() != y.size()) {
       throw Exception("x and y vector sizes do not match");
     }
-    auto data = std::make_shared<DataWithAesthetic>();
-    data->set(Aesthetic::x(), x);
-    data->set(Aesthetic::y(), y);
-    return add_frame(data, time);
+    return add_frame(DataWithAesthetic().x(x).y(y), time);
   }
 
-  void add_frame(const std::shared_ptr<DataWithAesthetic> &data, float time);
+  void add_frame(const DataWithAesthetic &data, float time);
 
   float get_time(const int i) const { return m_times[i]; }
 
-  const std::shared_ptr<DataWithAesthetic> &get_data(const int i) const {
-    return m_data[i];
-  }
-  std::shared_ptr<DataWithAesthetic> &get_data(const int i) {
-    return m_data[i];
-  }
+  const DataWithAesthetic &get_data(const int i) const { return m_data[i]; }
+  DataWithAesthetic &get_data(const int i) { return m_data[i]; }
   size_t data_size() const { return m_data.size(); }
 
   void set_color(const RGBA &color) { m_color = color; }

--- a/src/frontend/Plot1DDraw.hpp
+++ b/src/frontend/Plot1DDraw.hpp
@@ -33,9 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 
-#include "frontend/LineDraw.hpp"
 #include "frontend/Plot1D.hpp"
-#include "frontend/PointsDraw.hpp"
 
 namespace trase {
 

--- a/src/frontend/PointsDraw.hpp
+++ b/src/frontend/PointsDraw.hpp
@@ -55,12 +55,12 @@ template <typename Backend> void Points::serialise_frames(Backend &backend) {
   };
 
   backend.stroke_width(0);
-  for (int i = 0; i < m_data[0]->rows(); ++i) {
+  for (int i = 0; i < m_data[0].rows(); ++i) {
     for (size_t f = 0; f < m_times.size(); ++f) {
-      auto p = to_pixel(m_data[f]->begin<Aesthetic::x>()[i],
-                        m_data[f]->begin<Aesthetic::y>()[i],
-                        m_data[f]->begin<Aesthetic::color>()[i],
-                        m_data[f]->begin<Aesthetic::size>()[i]);
+      auto p = to_pixel(m_data[f].begin<Aesthetic::x>()[i],
+                        m_data[f].begin<Aesthetic::y>()[i],
+                        m_data[f].begin<Aesthetic::color>()[i],
+                        m_data[f].begin<Aesthetic::size>()[i]);
 
       backend.fill_color(m_colormap->to_color(p[2]));
       backend.add_animated_circle({p[0], p[1]}, p[3], m_times[f]);
@@ -86,26 +86,26 @@ template <typename Backend> void Points::draw_plot(Backend &backend) {
 
   if (w2 == 0.0f) {
     // exactly on a single frame
-    auto x = m_data[f]->begin<Aesthetic::x>();
-    auto y = m_data[f]->begin<Aesthetic::y>();
-    auto color = m_data[f]->begin<Aesthetic::color>();
-    auto size = m_data[f]->begin<Aesthetic::size>();
-    for (int i = 0; i < m_data[0]->rows(); ++i) {
+    auto x = m_data[f].begin<Aesthetic::x>();
+    auto y = m_data[f].begin<Aesthetic::y>();
+    auto color = m_data[f].begin<Aesthetic::color>();
+    auto size = m_data[f].begin<Aesthetic::size>();
+    for (int i = 0; i < m_data[0].rows(); ++i) {
       const auto p = to_pixel(x[i], y[i], color[i], size[i]);
       backend.fill_color(m_colormap->to_color(p[2]));
       backend.circle({p[0], p[1]}, p[3]);
     }
   } else {
     // between two frames
-    auto x0 = m_data[f - 1]->begin<Aesthetic::x>();
-    auto y0 = m_data[f - 1]->begin<Aesthetic::y>();
-    auto color0 = m_data[f - 1]->begin<Aesthetic::color>();
-    auto size0 = m_data[f - 1]->begin<Aesthetic::size>();
-    auto x1 = m_data[f]->begin<Aesthetic::x>();
-    auto y1 = m_data[f]->begin<Aesthetic::y>();
-    auto color1 = m_data[f]->begin<Aesthetic::color>();
-    auto size1 = m_data[f]->begin<Aesthetic::size>();
-    for (int i = 0; i < m_data[0]->rows(); ++i) {
+    auto x0 = m_data[f - 1].begin<Aesthetic::x>();
+    auto y0 = m_data[f - 1].begin<Aesthetic::y>();
+    auto color0 = m_data[f - 1].begin<Aesthetic::color>();
+    auto size0 = m_data[f - 1].begin<Aesthetic::size>();
+    auto x1 = m_data[f].begin<Aesthetic::x>();
+    auto y1 = m_data[f].begin<Aesthetic::y>();
+    auto color1 = m_data[f].begin<Aesthetic::color>();
+    auto size1 = m_data[f].begin<Aesthetic::size>();
+    for (int i = 0; i < m_data[0].rows(); ++i) {
       const auto p = w1 * to_pixel(x1[i], y1[i], color1[i], size1[i]) +
                      w2 * to_pixel(x0[i], y0[i], color0[i], size0[i]);
       backend.fill_color(m_colormap->to_color(p[2]));

--- a/src/frontend/Transform.cpp
+++ b/src/frontend/Transform.cpp
@@ -82,13 +82,10 @@ DataWithAesthetic BinX::operator()(const DataWithAesthetic &data) {
 
   const float dx = m_span.delta()[0] / m_number_of_bins;
 
-  std::vector<float> bin_x(m_number_of_bins), bin_y(m_number_of_bins);
+  std::vector<float> bin_y(m_number_of_bins);
 
-  // fill x bin coordinates as centre of each bin, zero y bin values
-  for (int i = 0; i < m_number_of_bins; ++i) {
-    bin_x[i] = m_span.bmin[0] + (i + 0.5f) * dx;
-    bin_y[i] = 0.f;
-  }
+  // zero y bin values
+  std::fill(bin_y.begin(), bin_y.end(), 0.f);
 
   //  accumulate data into histogram
   std::for_each(x_begin, x_end, [&](const float x) {
@@ -98,8 +95,11 @@ DataWithAesthetic BinX::operator()(const DataWithAesthetic &data) {
     }
   });
 
-  // return new data set
-  return DataWithAesthetic().x(bin_x).y(bin_y);
+  // return new data set, making sure to set ymin to zero
+  DataWithAesthetic ret;
+  ret.x(m_span.bmin[0], m_span.bmax[0]).y(bin_y);
+  ret.y(0.f, ret.limits().bmax[Aesthetic::y::index]);
+  return ret;
 }
 
 } // namespace trase

--- a/src/frontend/Transform.cpp
+++ b/src/frontend/Transform.cpp
@@ -55,9 +55,9 @@ DataWithAesthetic BinX::operator()(const DataWithAesthetic &data) {
     // increase the span slightly so round-off doesn't cause points to fall
     // outside the domain
     m_span.bmin[0] =
-        *minmax.first - 1e4 * std::numeric_limits<float>::epsilon();
+        *minmax.first - 1e4f * std::numeric_limits<float>::epsilon();
     m_span.bmin[1] =
-        *minmax.second + 1e4 * std::numeric_limits<float>::epsilon();
+        *minmax.second + 1e4f * std::numeric_limits<float>::epsilon();
   }
 
   if (m_number_of_bins == -1) {
@@ -75,7 +75,8 @@ DataWithAesthetic BinX::operator()(const DataWithAesthetic &data) {
     // Scott, D. 1979.
     // On optimal and data-based histograms.
     // Biometrika, 66:605-610.
-    const float dx = 3.49f * stdev * std::pow(data.rows(), -0.33f);
+    const float dx =
+        3.49f * stdev * std::pow(static_cast<float>(data.rows()), -0.33f);
     m_number_of_bins = static_cast<int>(std::round(m_span.delta()[0] / dx));
   }
 

--- a/src/frontend/Transform.cpp
+++ b/src/frontend/Transform.cpp
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2018, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of trase.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+#include "frontend/Transform.hpp"
+
+namespace trase {
+
+BinX::BinX(const int number_of_bins) : m_number_of_bins(number_of_bins) {}
+BinX::BinX(const int number_of_bins, const float min, const float max)
+    : m_number_of_bins(number_of_bins),
+      m_span(Vector<float, 1>(min), Vector<float, 1>({max})) {}
+
+DataWithAesthetic BinX::operator()(const DataWithAesthetic &data) {
+  auto x_begin = data.begin<Aesthetic::x>();
+  auto x_end = data.end<Aesthetic::x>();
+  auto minmax = std::minmax_element(x_begin, x_end);
+
+  if (m_span.is_empty()) {
+    // increase the span slightly so round-off doesn't cause points to fall
+    // outside the domain
+    m_span.bmin[0] =
+        *minmax.first - 1e4 * std::numeric_limits<float>::epsilon();
+    m_span.bmin[1] =
+        *minmax.second + 1e4 * std::numeric_limits<float>::epsilon();
+  }
+
+  if (m_number_of_bins == -1) {
+    auto sum = std::accumulate(x_begin, x_end, 0.f);
+    auto mean = sum / data.rows();
+
+    // note: use std::transform_reduce after c++17
+    std::vector<float> diff(data.rows());
+    std::transform(x_begin, x_end, diff.begin(),
+                   [mean](float x) { return x - mean; });
+    auto sq_sum =
+        std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.f);
+    auto stdev = std::sqrt(sq_sum / data.rows());
+
+    // Scott, D. 1979.
+    // On optimal and data-based histograms.
+    // Biometrika, 66:605-610.
+    const float dx = 3.49f * stdev * std::pow(data.rows(), -0.33f);
+    m_number_of_bins = static_cast<int>(std::round(m_span.delta()[0] / dx));
+  }
+
+  const float dx = m_span.delta()[0] / m_number_of_bins;
+
+  std::vector<float> bin_x(m_number_of_bins), bin_y(m_number_of_bins);
+
+  // fill x bin coordinates as centre of each bin, zero y bin values
+  for (int i = 0; i < m_number_of_bins; ++i) {
+    bin_x[i] = m_span.bmin[0] + (i + 0.5f) * dx;
+    bin_y[i] = 0.f;
+  }
+
+  //  accumulate data into histogram
+  std::for_each(x_begin, x_end, [&](const float x) {
+    const auto i = static_cast<int>(std::floor((x - m_span.bmin[0]) / dx));
+    if (i >= 0 && i < m_number_of_bins) {
+      ++(bin_y[i]);
+    }
+  });
+
+  // return new data set
+  return DataWithAesthetic().x(bin_x).y(bin_y);
+}
+
+} // namespace trase

--- a/src/frontend/Transform.hpp
+++ b/src/frontend/Transform.hpp
@@ -34,32 +34,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef TRANSFORM_H_
 #define TRANSFORM_H_
 
-#include <algorithm>
-#include <cmath>
 #include <functional>
-#include <numeric>
-#include <vector>
 
 #include "frontend/Data.hpp"
+#include "util/BBox.hpp"
 
 namespace trase {
-
-/// holds a `std::function` that maps between two DataWithAesthetic classes
-class Transform {
-  std::function<DataWithAesthetic(const DataWithAesthetic &)> m_transform;
-
-public:
-  /// construct a Transform wrapping the given transform function T. The
-  /// function T can be any function or function object that is compatible with
-  /// `std::function`
-  template <typename T>
-  explicit Transform(const T &transform) : m_transform(transform) {}
-
-  /// perform mapping on `data`, return result
-  DataWithAesthetic operator()(const DataWithAesthetic &data) const {
-    return m_transform(data);
-  }
-};
 
 /// Identity transform, just pass through...
 struct Identity {
@@ -71,57 +51,34 @@ struct Identity {
 /// bin x coordinates
 ///
 /// Requires x aesthetic.
-struct BinX {
+class BinX {
   int m_number_of_bins{-1};
+  bbox<float, 1> m_span;
+
+public:
   BinX() = default;
-  explicit BinX(const int number_of_bins) : m_number_of_bins(number_of_bins) {}
-  DataWithAesthetic operator()(const DataWithAesthetic &data) const {
-    auto x_begin = data.begin<Aesthetic::x>();
-    auto x_end = data.end<Aesthetic::x>();
-    auto minmax = std::minmax_element(x_begin, x_end);
-    const auto span = *minmax.second - *minmax.first;
+  explicit BinX(const int number_of_bins);
+  explicit BinX(const int number_of_bins, const float min, const float max);
+  DataWithAesthetic operator()(const DataWithAesthetic &data);
+};
 
-    double dx;
-    int n;
-    if (m_number_of_bins == -1) {
-      auto sum = std::accumulate(x_begin, x_end, 0.f);
-      auto mean = sum / data.rows();
+/// holds a `std::function` that maps between two DataWithAesthetic classes
+class Transform {
+  std::function<DataWithAesthetic(const DataWithAesthetic &)> m_transform;
 
-      // note: use std::transform_reduce after c++17
-      std::vector<float> diff(data.rows());
-      std::transform(x_begin, x_end, diff.begin(),
-                     [mean](double x) { return x - mean; });
-      double sq_sum =
-          std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0);
-      double stdev = std::sqrt(sq_sum / data.rows());
+public:
+  /// construct an identity transform
+  Transform() : m_transform(Identity()) {}
 
-      // Scott, D. 1979.
-      // On optimal and data-based histograms.
-      // Biometrika, 66:605-610.
-      dx = 3.49f * stdev * std::pow(data.rows(), -0.33f);
-      n = static_cast<int>(std::round(span / dx));
-      dx = span / n;
-    } else {
-      dx = span / m_number_of_bins;
-      n = m_number_of_bins;
-    }
+  /// construct a Transform wrapping the given transform function T. The
+  /// function T can be any function or function object that is compatible with
+  /// `std::function`
+  template <typename T>
+  explicit Transform(const T &transform) : m_transform(transform) {}
 
-    std::vector<float> bin_x(n), bin_y(n);
-
-    // fill x bin coordinates as centre of each bin
-    for (int i = 0; i < n; ++i) {
-      bin_x[i] = *minmax.first + (i + 0.5f) * dx;
-    }
-
-    //  accumulate data into histogram
-    std::for_each(x_begin, x_end,
-                  [min = *minmax.first, dx, &bin_y](const float x) {
-                    const auto i = static_cast<int>((x - min) / dx);
-                    ++(bin_y[i]);
-                  });
-
-    // return new data set
-    return DataWithAesthetic().x(bin_x).y(bin_y);
+  /// perform mapping on `data`, return result
+  DataWithAesthetic operator()(const DataWithAesthetic &data) {
+    return m_transform(data);
   }
 };
 

--- a/src/frontend/Transform.hpp
+++ b/src/frontend/Transform.hpp
@@ -57,8 +57,8 @@ class BinX {
 
 public:
   BinX() = default;
-  explicit BinX(const int number_of_bins);
-  explicit BinX(const int number_of_bins, const float min, const float max);
+  explicit BinX(int number_of_bins);
+  explicit BinX(int number_of_bins, float min, float max);
   DataWithAesthetic operator()(const DataWithAesthetic &data);
 };
 

--- a/src/frontend/Transform.hpp
+++ b/src/frontend/Transform.hpp
@@ -56,14 +56,16 @@ public:
   explicit Transform(const T &transform) : m_transform(transform) {}
 
   /// perform mapping on `data`, return result
-  DataWithAesthetic operator()(const DataWithAesthetic &data) {
+  DataWithAesthetic operator()(const DataWithAesthetic &data) const {
     return m_transform(data);
   }
 };
 
 /// Identity transform, just pass through...
 struct Identity {
-  DataWithAesthetic operator()(const DataWithAesthetic &data) { return data; }
+  DataWithAesthetic operator()(const DataWithAesthetic &data) const {
+    return data;
+  }
 };
 
 /// bin x coordinates
@@ -73,7 +75,7 @@ struct BinX {
   int m_number_of_bins{-1};
   BinX() {}
   BinX(const int number_of_bins) : m_number_of_bins(number_of_bins) {}
-  DataWithAesthetic operator()(const DataWithAesthetic &data) {
+  DataWithAesthetic operator()(const DataWithAesthetic &data) const {
     auto x_begin = data.begin<Aesthetic::x>();
     auto x_end = data.end<Aesthetic::x>();
     int n;
@@ -82,7 +84,7 @@ struct BinX {
       auto mean = sum / data.rows();
 
       // note: use std::transform_reduce after c++17
-      std::vector<float> diff(data.size());
+      std::vector<float> diff(data.rows());
       std::transform(x_begin, x_end, diff.begin(),
                      [mean](double x) { return x - mean; });
       double sq_sum =
@@ -113,10 +115,8 @@ struct BinX {
                     ++(bin_y[i]);
                   });
 
-    data.set<Aesthetic::x>(bin_x);
-    data.set<Aesthetic::y>(bin_y);
-
-    return data;
+    // return new data set
+    return DataWithAesthetic().x(bin_x).y(bin_y);
   }
 };
 

--- a/src/util/ColumnIterator.hpp
+++ b/src/util/ColumnIterator.hpp
@@ -38,17 +38,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace trase {
 
-/// An iterator that iterates through a single column of the raw data class
+/// A const iterator that iterates through a single column of the raw data class
 /// Impliments an random access iterator with a given stride
 class ColumnIterator {
 public:
-  using pointer = float *;
+  using pointer = float const *;
   using iterator_category = std::random_access_iterator_tag;
-  using reference = float &;
-  using value_type = float;
+  using reference = float const &;
+  using value_type = float const;
   using difference_type = std::ptrdiff_t;
 
-  ColumnIterator(const std::vector<float>::iterator &p, const int stride)
+  ColumnIterator() = default;
+
+  ColumnIterator(const std::vector<float>::const_iterator &p, const int stride)
       : m_p(&(*p)), m_stride(stride) {}
 
   reference operator*() const { return dereference(); }
@@ -93,7 +95,7 @@ private:
 
   void increment(const int n) { std::advance(m_p, n * m_stride); }
 
-  float *m_p;
+  pointer m_p;
   int m_stride;
 };
 

--- a/tests/TestAxis.cpp
+++ b/tests/TestAxis.cpp
@@ -104,9 +104,11 @@ TEST_CASE("labels", "[axis]") {
   auto ax = fig->axis();
   const std::vector<float> x = {1.f, 2.f, 3.f};
   const std::vector<float> y = {1.f, 2.f, 3.f};
-  auto plot1 = ax->plot(x, y, "plot1");
+  auto plot1 = ax->plot(x, y);
+  plot1->set_label("plot1");
   CHECK(plot1->get_label() == "plot1");
-  auto plot2 = ax->plot(x, y, "plot2");
+  auto plot2 = ax->plot(x, y);
+  plot2->set_label("plot2");
   CHECK(plot1->get_label() == "plot1");
   CHECK(plot2->get_label() == "plot2");
   auto plot3 = ax->plot(x, y);

--- a/tests/TestBackendSVG.cpp
+++ b/tests/TestBackendSVG.cpp
@@ -100,15 +100,17 @@ TEST_CASE("figure can written using SVG backend", "[figure]") {
 
   // create a static sin(x) function
   write_y(1.f, 2.f);
-  auto static_plot = ax->plot(x, y, "static");
+  auto static_plot = ax->plot(x, y);
+  static_plot->set_label("static");
 
   // create a moving sin(x) function with varying amplitude
   write_y(1.f, 5.f);
-  auto moving_plot = ax->plot(x, y, "moving");
+  auto moving_plot = ax->plot(x, y);
+  moving_plot->set_label("moving");
 
-  auto data = std::make_shared<DataWithAesthetic>();
-  data->x(x).y(y).color(r).size(r);
-  auto points = ax->points(data, "points");
+  auto data = DataWithAesthetic().x(x).y(y).color(r).size(r);
+  auto points = ax->points(data);
+  points->set_label("points");
 
   for (int i = 1; i <= nframes; ++i) {
     const float nf = static_cast<float>(nframes);
@@ -116,8 +118,7 @@ TEST_CASE("figure can written using SVG backend", "[figure]") {
     write_y(amplitude, 5.f);
     moving_plot->add_frame(x, y, 3.f * i / nf);
 
-    auto data = std::make_shared<DataWithAesthetic>();
-    data->x(x).y(y).color(r).size(r);
+    auto data = DataWithAesthetic().x(x).y(y).color(r).size(r);
     points->add_frame(data, 3.f * i / nf);
   }
 

--- a/tests/TestBackendSVG.cpp
+++ b/tests/TestBackendSVG.cpp
@@ -155,7 +155,7 @@ TEST_CASE("histogram looks ok", "[svg_backend]") {
   float time = 0.0;
 
   auto do_plot = [&](const float theta) {
-    time += 0.3;
+    time += 0.3f;
     std::normal_distribution<float> normal(theta, 1);
     std::generate(x.begin(), x.end(), [&]() { return normal(gen); });
     auto data = DataWithAesthetic().x(x);

--- a/tests/TestData.cpp
+++ b/tests/TestData.cpp
@@ -86,6 +86,28 @@ TEST_CASE("add some cols to raw data", "[data]") {
       CHECK(*i == second_col[ii]);
     }
   }
+
+  std::vector<float> second_col_overwrite_incorrect = {3, 2, 1, 0};
+  std::vector<float> second_col_overwrite = {3, 2, 1};
+
+  CHECK_THROWS_AS(data.set_column(1, second_col_incorrect), Exception);
+  CHECK_THROWS_AS(data.set_column(-1, second_col_overwrite), std::out_of_range);
+  CHECK_THROWS_AS(data.set_column(2, second_col_overwrite), std::out_of_range);
+  data.set_column(1, second_col_overwrite);
+
+  {
+    int ii = 0;
+    for (auto i = data.begin(0); i != data.end(0); ++i, ++ii) {
+      CHECK(*i == first_col[ii]);
+    }
+  }
+
+  {
+    int ii = 0;
+    for (auto i = data.begin(1); i != data.end(1); ++i, ++ii) {
+      CHECK(*i == second_col_overwrite[ii]);
+    }
+  }
 }
 
 TEST_CASE("create data with aesthetics", "[data]") {

--- a/tests/TestInteractive.cpp
+++ b/tests/TestInteractive.cpp
@@ -57,13 +57,15 @@ TEST_CASE("interactive test (only run by a human)", "[interactive]") {
     y[i] = std::sin(5 * x[i]);
     r[i] = 0.1;
   }
-  auto static_plot = ax->plot(x, y, "static");
-  auto moving_plot = ax->plot(x, y, "moving");
+  auto static_plot = ax->plot(x, y);
+  static_plot->set_label("static");
+  auto moving_plot = ax->plot(x, y);
+  moving_plot->set_label("moving");
 
-  auto data = moving_plot->get_data(0);
-  data->color(r).size(r);
+  auto data = moving_plot->get_data(0).color(r).size(r);
 
-  auto points = ax->points(data, "points");
+  auto points = ax->points(data);
+  points->set_label("points");
 
   std::cout << "limits of axis after points are: " << ax->limits() << std::endl;
 
@@ -75,8 +77,7 @@ TEST_CASE("interactive test (only run by a human)", "[interactive]") {
       y[i] = std::sin(theta * x[i]);
       r[i] = time * 0.1;
     }
-    auto data = std::make_shared<DataWithAesthetic>();
-    data->x(x).y(y).color(r).size(r);
+    auto data = DataWithAesthetic().x(x).y(y).color(r).size(r);
     moving_plot->add_frame(data, time);
     points->add_frame(data, time);
   };
@@ -109,45 +110,32 @@ TEST_CASE("histogram", "[interactive]") {
   const int n = 100;
   std::vector<float> x(n);
   std::default_random_engine gen;
-  std::normal_distribution<float> normal;
+  std::normal_distribution<float> normal(0, 1);
   std::generate(x.begin(), x.end(), [&]() { return normal(gen); });
 
-  auto data = std::make_shared<DataWithAesthetic>();
-  data->x(x);
+  auto data = DataWithAesthetic().x(x);
 
-  auto hist = ax->histogram(data, "hist");
-
-  std::cout << "limits of axis after points are: " << ax->limits() << std::endl;
+  auto hist = ax->histogram(data);
+  hist->set_label("hist");
 
   float time = 0.0;
 
   auto do_plot = [&](const float theta) {
     time += 0.3;
-    for (int i = 0; i < n; ++i) {
-      y[i] = std::sin(theta * x[i]);
-      r[i] = time * 0.1;
-    }
-    auto data = std::make_shared<DataWithAesthetic>();
-    data->x(x).y(y).color(r).size(r);
-    moving_plot->add_frame(data, time);
-    points->add_frame(data, time);
+    std::normal_distribution<float> normal(0, 1 + time);
+    std::generate(x.begin(), x.end(), [&]() { return normal(gen); });
+    auto data = DataWithAesthetic().x(x);
+    hist->add_frame(data, time);
   };
 
   for (int i = 0; i < 5; ++i) {
     const float theta = 5 - i;
     do_plot(theta);
   }
-  for (int i = 4; i >= 0; --i) {
-    const float theta = 5 - i;
-    do_plot(theta);
-  }
-
-  std::cout << "limits of axis after all  points are: " << ax->limits()
-            << std::endl;
 
   ax->xlabel("x");
   ax->ylabel("y");
-  ax->title("the interactive test");
+  ax->title("histogram test");
   ax->legend();
 
   BackendGL backend;

--- a/tests/TestInteractive.cpp
+++ b/tests/TestInteractive.cpp
@@ -91,9 +91,6 @@ TEST_CASE("interactive test (only run by a human)", "[interactive]") {
     do_plot(theta);
   }
 
-  std::cout << "limits of axis after all  points are: " << ax->limits()
-            << std::endl;
-
   ax->xlabel("x");
   ax->ylabel("y");
   ax->title("the interactive test");
@@ -127,6 +124,9 @@ TEST_CASE("histogram", "[interactive]") {
     auto data = DataWithAesthetic().x(x);
     hist->add_frame(data, time);
   };
+
+  std::cout << "limits of axis after all  histograms are: " << ax->limits()
+            << std::endl;
 
   for (int i = 0; i < 5; ++i) {
     const float theta = i / 5.f;

--- a/tests/TestInteractive.cpp
+++ b/tests/TestInteractive.cpp
@@ -122,14 +122,14 @@ TEST_CASE("histogram", "[interactive]") {
 
   auto do_plot = [&](const float theta) {
     time += 0.3;
-    std::normal_distribution<float> normal(0, 1 + time);
+    std::normal_distribution<float> normal(theta, 1);
     std::generate(x.begin(), x.end(), [&]() { return normal(gen); });
     auto data = DataWithAesthetic().x(x);
     hist->add_frame(data, time);
   };
 
   for (int i = 0; i < 5; ++i) {
-    const float theta = 5 - i;
+    const float theta = i / 5.f;
     do_plot(theta);
   }
 

--- a/tests/TestInteractive.cpp
+++ b/tests/TestInteractive.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include <limits>
+#include <random>
 #include <type_traits>
 
 #include "backend/BackendGL.hpp"
@@ -64,6 +64,58 @@ TEST_CASE("interactive test (only run by a human)", "[interactive]") {
   data->color(r).size(r);
 
   auto points = ax->points(data, "points");
+
+  std::cout << "limits of axis after points are: " << ax->limits() << std::endl;
+
+  float time = 0.0;
+
+  auto do_plot = [&](const float theta) {
+    time += 0.3;
+    for (int i = 0; i < n; ++i) {
+      y[i] = std::sin(theta * x[i]);
+      r[i] = time * 0.1;
+    }
+    auto data = std::make_shared<DataWithAesthetic>();
+    data->x(x).y(y).color(r).size(r);
+    moving_plot->add_frame(data, time);
+    points->add_frame(data, time);
+  };
+
+  for (int i = 0; i < 5; ++i) {
+    const float theta = 5 - i;
+    do_plot(theta);
+  }
+  for (int i = 4; i >= 0; --i) {
+    const float theta = 5 - i;
+    do_plot(theta);
+  }
+
+  std::cout << "limits of axis after all  points are: " << ax->limits()
+            << std::endl;
+
+  ax->xlabel("x");
+  ax->ylabel("y");
+  ax->title("the interactive test");
+  ax->legend();
+
+  BackendGL backend;
+  fig->show(backend);
+}
+
+TEST_CASE("histogram", "[interactive]") {
+
+  auto fig = figure();
+  auto ax = fig->axis();
+  const int n = 100;
+  std::vector<float> x(n);
+  std::default_random_engine gen;
+  std::normal_distribution<float> normal;
+  std::generate(x.begin(), x.end(), [&]() { return normal(gen); });
+
+  auto data = std::make_shared<DataWithAesthetic>();
+  data->x(x);
+
+  auto hist = ax->histogram(data, "hist");
 
   std::cout << "limits of axis after points are: " << ax->limits() << std::endl;
 


### PR DESCRIPTION
This PR follows on from #71 and is about adding the histogram geometry. 

This is the first geometry that really uses the transforms, so I found  a few API changes I wanted to make. The PR is not finished, I just want to get feedback on the new API changes. These are:

1. `DataWithAesthetics` is held by value in `Plot1D`, rather than using `std::shared_ptr`. Reasoning is that the `RawData` held by `DataWithAesthetics` is already held using `std::shared_ptr`, so there is no reason to use a pointer for `DataWithAesthetics`, since it actually does not hold any data other than the mapping of aesthetics to columns. It also simplifies the transform, as it is a mapping from `DataWithAesthetics` to `DataWithAesthetics`, and it is easier to write a mapping between two value types rather than two `std::shared_ptr`s. As a bonus, this really simplifies the creation and setting of the `DataWithAesthetics` class, since you can just do:

```cpp
auto data = DataWithAesthetics().x(my_x_vector).y(my_y_vector).color(and_so_on);
```
2. The plot creation functions in `Axis` no longer accept a `std::string` for a plot label. This argument has been replaced by a `Transform` argument, which has a default. Reasoning is that it is awkward to have more than one function argument with a default.

3. The `ColumnIterator` has been changed to a const iterator. Reasoning is that the transforms take in a const reference to a `DataWithAesthetics`, so need a const iterator to access the data.

@fcooper8472, what do you think of these three changes?