### PR TITLE
#86 show throws on non-interactive backend

### DIFF
--- a/src/backend/BackendSVG.cpp
+++ b/src/backend/BackendSVG.cpp
@@ -85,7 +85,25 @@ function remove_tooltip() {
 
 bool BackendSVG::is_interactive() { return false; }
 
+bool BackendSVG::should_close() { return true; }
+
+vfloat2_t BackendSVG::begin_frame() { return vfloat2_t(); }
+
+void BackendSVG::end_frame() {}
+
 vfloat2_t BackendSVG::get_mouse_pos() { return vfloat2_t(0, 0); }
+
+float BackendSVG::get_time() { return 0.f; }
+
+void BackendSVG::set_mouse_down(const vfloat2_t &mouse_pos) {}
+
+void BackendSVG::set_mouse_up() {}
+
+bool BackendSVG::mouse_dragging() { return false; }
+
+vfloat2_t BackendSVG::mouse_drag_delta() { return vfloat2_t(); }
+
+void BackendSVG::mouse_drag_reset_delta() {}
 
 void BackendSVG::scissor(const bfloat2_t &x) {}
 
@@ -388,7 +406,8 @@ void BackendSVG::add_animated_rect(const bfloat2_t &x, float time) {
 void BackendSVG::add_animated_stroke(const RGBA &color) {
   if (m_animate_stroke.empty()) {
     m_animate_stroke = "values=\"" + color.to_rgb_string() + ';';
-    m_animate_stroke_opacity = "values=\"" + std::to_string(color.a() / 255.0) + ';';
+    m_animate_stroke_opacity =
+        "values=\"" + std::to_string(color.a() / 255.0) + ';';
   } else {
     m_animate_stroke += color.to_rgb_string() + ';';
     m_animate_stroke_opacity += std::to_string(color.a() / 255.0) + ';';
@@ -415,7 +434,8 @@ void BackendSVG::end_animate_stroke() {
 void BackendSVG::add_animated_fill(const RGBA &color) {
   if (m_animate_fill.empty()) {
     m_animate_fill = "values=\"" + color.to_rgb_string() + ';';
-    m_animate_fill_opacity = "values=\"" + std::to_string(color.a() / 255.0) + ';';
+    m_animate_fill_opacity =
+        "values=\"" + std::to_string(color.a() / 255.0) + ';';
   } else {
     m_animate_fill += color.to_rgb_string() + ';';
     m_animate_fill_opacity += std::to_string(color.a() / 255.0) + ';';

--- a/src/backend/BackendSVG.cpp
+++ b/src/backend/BackendSVG.cpp
@@ -357,15 +357,7 @@ void BackendSVG::rect_begin(const bfloat2_t &x, float r) noexcept {
     m_out << m_att("rx", r) << m_att("ry", r);
   }
 
-  // Styling
-  m_out << m_fill_color << ' ' << m_line_color << ' ' << m_linewidth;
-
-  if (mouseover()) {
-    m_out << " onmouseover=\"" << m_onmouseover_fill << m_onmouseover_stroke
-          << m_onmouseover_tooltip << '\"';
-    m_out << " onmouseout=\"" << m_onmouseout_fill << m_onmouseout_stroke
-          << m_onmouseout_tooltip << '\"';
-  }
+  shape_styling();
 
   m_out << ">\n";
 }
@@ -462,11 +454,7 @@ void BackendSVG::end_animated_rect() {
   m_animate_times.clear();
 }
 
-void BackendSVG::circle_begin(const vfloat2_t &centre, const float r) noexcept {
-
-  m_out << "<circle ";
-  m_out << m_att("cx", centre[0]) << m_att("cy", centre[1]) << m_att("r", r);
-
+void BackendSVG::shape_styling() {
   // Styling
   m_out << m_fill_color << ' ' << m_line_color << ' ' << m_linewidth;
 
@@ -476,6 +464,14 @@ void BackendSVG::circle_begin(const vfloat2_t &centre, const float r) noexcept {
     m_out << " onmouseout=\"" << m_onmouseout_fill << m_onmouseout_stroke
           << m_onmouseout_tooltip << '\"';
   }
+}
+
+void BackendSVG::circle_begin(const vfloat2_t &centre, const float r) noexcept {
+
+  m_out << "<circle ";
+  m_out << m_att("cx", centre[0]) << m_att("cy", centre[1]) << m_att("r", r);
+
+  shape_styling();
 
   m_out << ">\n";
 }

--- a/src/backend/BackendSVG.hpp
+++ b/src/backend/BackendSVG.hpp
@@ -380,6 +380,7 @@ private:
   void end_animate(std::string &animate, const std::string &name);
   void end_animate_stroke();
   void end_animate_fill();
+  void shape_styling();
 };
 
 } // namespace trase

--- a/src/backend/BackendSVG.hpp
+++ b/src/backend/BackendSVG.hpp
@@ -147,8 +147,35 @@ public:
   /// returns false
   bool is_interactive();
 
+  /// returns true
+  bool should_close();
+
+  /// not used (only used for interactive backends)
+  vfloat2_t begin_frame();
+
+  /// not used (only used for interactive backends)
+  void end_frame();
+
   /// this backend is not interactive so return value is undefined
   vfloat2_t get_mouse_pos();
+
+  /// not used (only used for interactive backends)
+  float get_time();
+
+  /// not used (only used for interactive backends)
+  static void set_mouse_down(const vfloat2_t &mouse_pos);
+
+  /// not used (only used for interactive backends)
+  static void set_mouse_up();
+
+  /// not used (only used for interactive backends)
+  bool mouse_dragging();
+
+  /// not used (only used for interactive backends)
+  vfloat2_t mouse_drag_delta();
+
+  /// not used (only used for interactive backends)
+  void mouse_drag_reset_delta();
 
   /// all subsequent drawing calls will be cut to within this box
   void scissor(const bfloat2_t &x);

--- a/src/frontend/Data.cpp
+++ b/src/frontend/Data.cpp
@@ -195,7 +195,7 @@ float Aesthetic::size::from_display(const float display, const Limits &data_lim,
 }
 
 float Aesthetic::fill::to_display(const float data, const Limits &data_lim,
-                                   const bfloat2_t &display_lim) {
+                                  const bfloat2_t &display_lim) {
   (void)display_lim;
   float len_ratio = 1.f / (data_lim.bmax[index] - data_lim.bmin[index]);
 
@@ -203,9 +203,8 @@ float Aesthetic::fill::to_display(const float data, const Limits &data_lim,
   return rel_pos * len_ratio;
 }
 
-float Aesthetic::fill::from_display(const float display,
-                                     const Limits &data_lim,
-                                     const bfloat2_t &display_lim) {
+float Aesthetic::fill::from_display(const float display, const Limits &data_lim,
+                                    const bfloat2_t &display_lim) {
   (void)display_lim;
   float len_ratio = (data_lim.bmax[index] - data_lim.bmin[index]);
 
@@ -257,44 +256,23 @@ float Aesthetic::ymin::from_display(const float display, const Limits &data_lim,
 
 float Aesthetic::xmax::to_display(const float data, const Limits &data_lim,
                                   const bfloat2_t &display_lim) {
-  const int xindex = Aesthetic::x::index;
-  float len_ratio = (display_lim.bmax[0] - display_lim.bmin[0]) /
-                    (data_lim.bmax[xindex] - data_lim.bmin[xindex]);
-
-  float rel_pos = data - data_lim.bmin[xindex];
-  return display_lim.bmin[0] + rel_pos * len_ratio;
+  return Aesthetic::xmin::to_display(data, data_lim, display_lim);
 }
 
 float Aesthetic::xmax::from_display(const float display, const Limits &data_lim,
                                     const bfloat2_t &display_lim) {
-  const int xindex = Aesthetic::x::index;
-  float len_ratio = (data_lim.bmax[xindex] - data_lim.bmin[xindex]) /
-                    (display_lim.bmax[1] - display_lim.bmin[1]);
-
-  float rel_pos = display - display_lim.bmin[1];
-  return data_lim.bmin[xindex] + rel_pos * len_ratio;
+  return Aesthetic::xmin::from_display(display, data_lim, display_lim);
 }
 
 /// the data to display on the y-axis of the plot
 float Aesthetic::ymax::to_display(const float data, const Limits &data_lim,
                                   const bfloat2_t &display_lim) {
-  const int yindex = Aesthetic::y::index;
-  float len_ratio = (display_lim.bmax[1] - display_lim.bmin[1]) /
-                    (data_lim.bmax[yindex] - data_lim.bmin[yindex]);
-
-  // Get the relative position and invert y by default (e.g. limits->pixels)
-  float rel_pos = data_lim.bmax[yindex] - data;
-  return display_lim.bmin[1] + rel_pos * len_ratio;
+  return Aesthetic::ymin::to_display(data, data_lim, display_lim);
 }
 
 float Aesthetic::ymax::from_display(const float display, const Limits &data_lim,
                                     const bfloat2_t &display_lim) {
-  const int yindex = Aesthetic::y::index;
-  float len_ratio = (data_lim.bmax[yindex] - data_lim.bmin[yindex]) /
-                    (display_lim.bmax[1] - display_lim.bmin[1]);
-
-  float rel_pos = display_lim.bmax[1] - display;
-  return data_lim.bmin[yindex] + rel_pos * len_ratio;
+  return Aesthetic::ymin::from_display(display, data_lim, display_lim);
 }
 
 template <>

--- a/src/frontend/Figure.tcc
+++ b/src/frontend/Figure.tcc
@@ -106,6 +106,11 @@ template <typename Backend> void Figure::show(Backend &backend) {
   auto name = "Figure " + std::to_string(m_id);
   backend.init(this->m_pixels.bmax, name.c_str());
 
+  if (!backend.is_interactive()) {
+    throw Exception("Figure::show() should only be called with interactive "
+                    "backends. Use Figure::draw() instead");
+  }
+
 // Main loop
 #ifdef __EMSCRIPTEN__
   auto data = std::make_pair(this, &backend);

--- a/tests/TestFigure.cpp
+++ b/tests/TestFigure.cpp
@@ -49,6 +49,14 @@ TEST_CASE("check figure can be created", "[figure]") {
   auto fig2 = figure({800, 600});
 }
 
+TEST_CASE("check show throws", "[figure]") {
+  auto fig = figure();
+  std::ofstream out;
+  out.open("test.svg");
+  BackendSVG backend(out);
+  REQUIRE_THROWS_WITH(fig->show(backend), Catch::Contains("Figure::show()"));
+}
+
 TEST_CASE("adding a single Axis object to Figure", "[figure]") {
   auto fig = figure();
 


### PR DESCRIPTION
Fixes #86 

Figure::show() now throws when given a non-interactive backend

was thinking that interactive backends should get their own base class, see #134 